### PR TITLE
Use current user id when saving images, rather than default value

### DIFF
--- a/app/models/image-set.js
+++ b/app/models/image-set.js
@@ -9,7 +9,7 @@ export default DS.Model.extend({
   isVerified: DS.attr('boolean'),
   hasCvResults: DS.attr('boolean'),
   images: DS.hasMany('images'),
-  userId: DS.attr('string'), // DS.belongsTo('user')
+  user: DS.belongsTo('user'),
   uploadingOrganization: DS.belongsTo('organization'),
 
   addImage: function(url, isPublic, imageType) {

--- a/app/routes/image-sets/new.js
+++ b/app/routes/image-sets/new.js
@@ -4,8 +4,9 @@ export default ImageSetRoute.extend({
   controllerName: 'image-set',
 
   model: function() {
+    var currentUser = this.get('toriiSession.currentUser');
     return this.store.createRecord('image-set', {
-      userId: '1' // TODO Remove once we have user auth. requires a user on the backend
+      user: currentUser
     });
   },
 

--- a/app/serializers/image-set.js
+++ b/app/serializers/image-set.js
@@ -2,6 +2,6 @@ import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
   attrs: {
-    images:    {serialize: 'records'}
+    images: {serialize: 'records'}
   }
 });

--- a/tests/unit/models/image-set-test.js
+++ b/tests/unit/models/image-set-test.js
@@ -5,7 +5,7 @@ import {
 import Ember from 'ember';
 
 moduleForModel('image-set', 'ImageSet', {
-  needs: ['model:image', 'model:organization']
+  needs: ['model:image', 'model:organization', 'model:user']
 });
 
 test('it exists', function() {

--- a/tests/unit/models/image-test.js
+++ b/tests/unit/models/image-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleForModel('image', 'Image', {
-  // Specify the other units that are required for this test.
-  needs: ['model:image-set', 'model:organization']
+  needs: ['model:image-set', 'model:organization', 'model:user']
 });
 
 test('it exists', function() {

--- a/tests/unit/models/lion-test.js
+++ b/tests/unit/models/lion-test.js
@@ -5,7 +5,7 @@ import {
 
 moduleForModel('lion', 'Lion', {
   // Specify the other units that are required for this test.
-  needs: ['model:image-set', 'model:organization', 'model:image']
+  needs: ['model:image-set', 'model:organization', 'model:image', 'model:user']
 });
 
 test('it exists', function() {


### PR DESCRIPTION
@iezer: A quick PR to use authenticated user id, rather than default value for saving images. This repairs image set save post-authentication work, as it was temporarily not working. 
