### PR TITLE
Delete image sets from image management page

### DIFF
--- a/app/controllers/image-set.js
+++ b/app/controllers/image-set.js
@@ -32,6 +32,14 @@ export default Ember.Controller.extend({
 
         controller.transitionToRoute('image-set', imageSet);
       });
+    },
+
+    deleteImageSet: function() {
+      var imageSet = this.get('model'),
+          controller = this;
+      imageSet.destroyRecord().then(function() {
+        controller.transitionToRoute('image-sets');
+      });
     }
   }
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -49,10 +49,26 @@ body > .ember-view {
     width: 50%;
   }
 
-  .image-set-save {
+  .image-set-save-or-delete {
     position: absolute;
     right: 0;
     top: 0;
+  }
+}
+
+.image-thumbnail {
+
+  img, .no-main-image {
+    border: 1px solid black;
+    border-radius: 5px;
+    height: 160px;
+  }
+
+  .no-main-image {
+    width: 160px;
+    text-align: center;
+    line-height: 160px;
+    color: #CCC;
   }
 }
 

--- a/app/styles/components.scss
+++ b/app/styles/components.scss
@@ -1,0 +1,17 @@
+
+.image-summary {
+  margin-top: 20px;
+
+  .panel {
+    position: relative;
+  }
+
+  .lg-image-set-summary-link {
+    position: absolute;
+    right: 0;
+    top: 0;
+    line-height: 35px;
+    padding-right: 10px;
+  }
+}
+

--- a/app/templates/components/lg-image-set-summary.hbs
+++ b/app/templates/components/lg-image-set-summary.hbs
@@ -1,15 +1,17 @@
-<div class='row'>
+<div class='image-summary row'>
   <div class='col-sm-4'>
     <div class='panel panel-default'>
       <div class='panel-heading'>
         Image Set
+        {{#link-to 'image-set' imageSet classNames='lg-image-set-summary-link'}}
+          <button class='btn btn-xs btn-success'>
+            View Details
+          </button>
+        {{/link-to}}
       </div>
       <ul class='list-group'>
         <li class='list-group-item'>
           ID: {{imageSet.id}}
-          {{#link-to 'image-set' imageSet classNames='lg-image-set-summary-link'}}
-            View Details
-          {{/link-to}}
         </li>
         <li class='list-group-item'>
           Status: {{status}}
@@ -20,7 +22,13 @@
       </ul>
     </div>
   </div>
-  <div class='col-sm-4'>
-    <img {{bind-attr src=imageSet.mainImage.url}} width='100' height='100'>
+  <div class='image-thumbnail col-sm-4'>
+    {{#if imageSet.mainImage}}
+      <img {{bind-attr src=imageSet.mainImage.url}}>
+    {{else}}
+      <div class='no-main-image'>
+        (Main Image)
+      </div>
+    {{/if}}
   </div>
 </div>

--- a/app/templates/image-set.hbs
+++ b/app/templates/image-set.hbs
@@ -2,9 +2,12 @@
   <div class='image-set-title'>
     <h2>Image Set</h2>
   </div>
-  <div class='image-set-save'>
+  <div class='image-set-save-or-delete'>
     <button class='btn btn-primary btn-large' type='button' {{action 'saveImageSet'}}>
       Save Image Set
+    </button>
+    <button class='btn btn-danger btn-large' type='button' {{action 'deleteImageSet'}}>
+      Delete Image Set
     </button>
   </div>
 </div>

--- a/tests/acceptance/image-sets-test.js
+++ b/tests/acceptance/image-sets-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
-import { stubGetOrganizations, stubGetImageSets } from '../helpers/fake-requests';
+import { stubGetOrganizations, stubGetImageSets, stubDeleteImageSets } from '../helpers/fake-requests';
 
 var application;
 
@@ -9,6 +9,7 @@ module('Acceptance: ImageSets', {
     application = startApp();
     stubGetImageSets();
     stubGetOrganizations();
+    stubDeleteImageSets();
   },
   teardown: function() {
     Ember.run(application, 'destroy');
@@ -30,5 +31,30 @@ test('visiting /image-sets', function() {
 
   andThen(function() {
     equal(currentURL(), '/image-set/24');
+  });
+});
+
+test('delete /image-set/:id', function() {
+  signIn();
+  visit('/image-sets');
+
+  andThen(function() {
+    equal(currentPath(), 'image-sets.index');
+    expectComponent('lg-image-set-summary');
+    expect('.image-set-summary:contains(24)', 1);
+  });
+
+  andThen(function() {
+    click('.lg-image-set-summary-link');
+  });
+
+  andThen(function() {
+    equal(currentURL(), '/image-set/24');
+    click('.image-set-save-or-delete button:last-child');
+  });
+
+  andThen(function() {
+    equal(currentURL(), '/image-sets');
+    expect('.image-set-summary:contains(24)', 0);
   });
 });

--- a/tests/acceptance/image-sets-test.js
+++ b/tests/acceptance/image-sets-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
-import { stubGetOrganizations, stubGetImageSets, stubDeleteImageSets } from '../helpers/fake-requests';
+import { stubGetOrganizations, stubGetImageSets } from '../helpers/fake-requests';
+import { stubRequest } from '../helpers/fake-server';
 
 var application;
 
@@ -9,7 +10,6 @@ module('Acceptance: ImageSets', {
     application = startApp();
     stubGetImageSets();
     stubGetOrganizations();
-    stubDeleteImageSets();
   },
   teardown: function() {
     Ember.run(application, 'destroy');
@@ -35,6 +35,13 @@ test('visiting /image-sets', function() {
 });
 
 test('delete /image-set/:id', function() {
+  expect(5);
+
+  stubRequest('delete', '/imageSets/24', function(request){
+    ok(true, 'delete api was called');
+    return this.noContent(204);
+  });
+
   signIn();
   visit('/image-sets');
 

--- a/tests/helpers/fake-requests.js
+++ b/tests/helpers/fake-requests.js
@@ -104,8 +104,17 @@ function stubGetImageSets() {
   });
 }
 
+function stubDeleteImageSets() {
+  stubRequest('delete', '/imageSets', function(request){
+    return this.success({
+      _embedded: {}
+    });
+  });
+}
+
 export {
   stubGetLions,
   stubGetOrganizations,
-  stubGetImageSets
+  stubGetImageSets,
+  stubDeleteImageSets
 };

--- a/tests/helpers/fake-requests.js
+++ b/tests/helpers/fake-requests.js
@@ -104,17 +104,8 @@ function stubGetImageSets() {
   });
 }
 
-function stubDeleteImageSets() {
-  stubRequest('delete', '/imageSets', function(request){
-    return this.success({
-      _embedded: {}
-    });
-  });
-}
-
 export {
   stubGetLions,
   stubGetOrganizations,
-  stubGetImageSets,
-  stubDeleteImageSets
+  stubGetImageSets
 };


### PR DESCRIPTION
@iezer This is missing tests, but wanted to get you an update tonight as the functionality is working. I'll follow up with some tests to confirm the behavior in the morning. 

This deletes whole image sets by sending a Delete call to the API server. The user is then routed back to the image-sets index page. 
