### PR TITLE
Image set index

### DIFF
--- a/app/components/lg-lion-search.js
+++ b/app/components/lg-lion-search.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import {searchGenders} from 'lion-guardians/utils/units';
 
 export default Ember.Component.extend({
+  store: null,
   genders: searchGenders,
   selectedGender: searchGenders[0],
   defaultGender: Ember.computed.alias('genders.firstObject'),
@@ -9,6 +10,7 @@ export default Ember.Component.extend({
   selectedOrganization: null,
   selectedName: null,
   action: null,
+  searchModel: 'lion',
 
   defaultOrganization: function(){
     return Ember.Object.create({
@@ -58,8 +60,16 @@ export default Ember.Component.extend({
 
   actions: {
     search: function() {
-      var params = this.get('params');
-      this.sendAction('action', params);
+      var params = this.get('params'),
+          store = this.get('store'),
+          component = this,
+          searchModel = this.get('searchModel');
+
+      store.find(searchModel, params).then(function(results){
+        component.sendAction('action', results);
+      }, function() {
+        alert("There was an error searching.");
+      });
     }
   }
 });

--- a/app/components/lg-selectable.js
+++ b/app/components/lg-selectable.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  model: null,
+  activeModel: null,
+  classNames: [],
+  classNameBindings: ["isActive:active"],
+
+  isActive: function() {
+    return this.get('model') === this.get('activeModel');
+  }.property('model', 'activeModel'),
+
+  actions: {
+    selectModel: function() {
+      var model = this.get('model');
+      this.sendAction('action', model);
+    }
+  }
+});

--- a/app/controllers/image-set.js
+++ b/app/controllers/image-set.js
@@ -40,18 +40,6 @@ export default Ember.Controller.extend({
       imageSet.destroyRecord().then(function() {
         controller.transitionToRoute('image-sets');
       });
-    },
-
-    requestCv: function() {
-      var imageSet = this.get('model'),
-          currentUser = this.get('toriiSession.currentUser');
-
-      var cvRequest = this.store.createRecord('cvRequest', {
-        imageSet: imageSet,
-        uploadingOrganization: currentUser.get('organization')
-      });
-
-      cvRequest.save();
     }
   }
 });

--- a/app/controllers/image-sets/index.js
+++ b/app/controllers/image-sets/index.js
@@ -1,6 +1,57 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
+  organizations: null,
   currentUser: null,
-  currentOrganization: Ember.computed.alias('currentUser.organization')
+  currentOrganization: Ember.computed.alias('currentUser.organization'),
+  activeImageSet: null,
+  selectedOrganization: Ember.computed.reads('currentOrganization'),
+
+  canView: Ember.computed.alias('activeImageSet'),
+  canRequestCv: Ember.computed.alias('activeImageSet'),
+  canViewCv: Ember.computed.alias('activeImageSet.hasCvResults'),
+  canDelete: function() {
+    return this.get('activeImageSet.uploadingOrganization') === this.get('currentOrganization');
+  }.property('activeImageSet.uploadingOrganization', 'currentOrganization'),
+
+  actions: {
+    displayResults: function(imageSets) {
+      this.set('model', imageSets);
+    },
+
+    selectImageSet: function(imageSet) {
+      this.set('activeImageSet', imageSet);
+    },
+
+    viewImageSet: function() {
+      var activeImageSet = this.get('activeImageSet');
+      if (activeImageSet) {
+        this.transitionToRoute('image-set', activeImageSet);
+      }
+    },
+
+    deleteImageSet: function() {
+      var activeImageSet = this.get('activeImageSet'),
+          canDelete = this.get('canDelete');
+
+      if (activeImageSet && canDelete) {
+        this.set('activeImageSet', null);
+        activeImageSet.destroyRecord();
+      }
+    },
+
+    viewCv: function() {
+      var activeImageSet = this.get('activeImageSet');
+      if (activeImageSet) {
+        this.transitionToRoute('image-set.cv-results', activeImageSet);
+      }
+    },
+
+    requestCv: function(activeImageSet) {
+      if (activeImageSet) {
+        // Bubble up to handler on application route
+        return true;
+      }
+    }
+  }
 });

--- a/app/controllers/lions/search.js
+++ b/app/controllers/lions/search.js
@@ -4,11 +4,8 @@ export default Ember.Controller.extend({
   organizations: null,
 
   actions: {
-    search: function(params) {
-      var controller = this;
-      this.store.find('lion', params).then(function(lions){
-        controller.set('model', lions);
-      });
+    displayResults: function(lions) {
+      this.set('model', lions);
     }
   }
 });

--- a/app/models/image-set.js
+++ b/app/models/image-set.js
@@ -16,6 +16,24 @@ export default DS.Model.extend({
   cvResults: DS.hasMany('cv-results', {async: true}),
   cvRequest: DS.belongsTo('cv-request', {async: true}),
 
+  status: function() {
+    var hasCvResults = this.get('hasCvResults'),
+        lion = this.get('lion'),
+        isVerified = this.get('isVerified'),
+        status = "";
+
+    if (hasCvResults && lion) {
+      status += 'Has CV Results, ';
+      status += isVerified ? 'Verified' : 'Unverified';
+    } else if (hasCvResults) {
+      status = 'Has CV Results';
+    } else if (lion) {
+      status = isVerified ? 'Verified' : 'Unverified';
+    }
+
+    return status;
+  }.property('hasCvResults', 'lion', 'isVerified'),
+
   addImage: function(url, isPublic, imageType) {
     var image = this.store.createRecord('image', {
       url: url,

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -13,6 +13,16 @@ export default Ember.Route.extend({
       this.get('toriiSession').close('lion-guardians').then(function(){
         route.transitionTo('login');
       });
+    },
+    requestCv: function(imageSet) {
+      var currentUser = this.get('toriiSession.currentUser');
+
+      var cvRequest = this.store.createRecord('cvRequest', {
+        imageSet: imageSet,
+        uploadingOrganization: currentUser.get('organization')
+      });
+
+      cvRequest.save();
     }
   }
 });

--- a/app/routes/image-sets/index.js
+++ b/app/routes/image-sets/index.js
@@ -1,6 +1,15 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  organizations: null,
+
+  beforeModel: function() {
+    var router = this;
+    return this.store.find('organization').then(function(organizations) {
+      router.set('organizations', organizations);
+    });
+  },
+
   model: function() {
     var currentOrganization = this.get('toriiSession.currentUser.organization');
     return this.store.find('imageSet', {
@@ -9,10 +18,12 @@ export default Ember.Route.extend({
   },
 
   setupController: function(controller, model) {
-    var currentUser = this.get('toriiSession.currentUser');
+    var currentUser = this.get('toriiSession.currentUser'),
+        organizations = this.get('organizations');
     controller.setProperties({
       currentUser: currentUser,
-      model: model
+      model: model,
+      organizations: organizations
     });
   }
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -129,3 +129,7 @@ body > .ember-view {
   padding-bottom: 5px;
   line-height: 20px;
 }
+
+.row.active {
+  color: red
+}

--- a/app/templates/components/lg-image-set-editor.hbs
+++ b/app/templates/components/lg-image-set-editor.hbs
@@ -34,7 +34,15 @@
         <li class='list-group-item'>Age: {{input type='text' placeholder='Age' value=selectedAge}}</li>
         <li class='list-group-item'>Lat/Long: {{selectedLatitude}} x {{selectedLongitude}}</li>
         <li class='list-group-item'>Gender: {{view 'select' classNames='lg-image-set-editor-gender' content=genders value=selectedGender}}</li>
-        <li class='list-group-item'>Verified: {{input type='checkbox' checked=selectedIsVerified}}</li>
+
+        {{#if imageSet.lion}}
+          <li class='list-group-item'>Lion:
+            {{#link-to 'lion' imageSet.lion classNames='lg-lion-summary-link'}}
+              {{imageSet.lion.name}}
+            {{/link-to}}
+          </li>
+          <li class='list-group-item'>Verified: {{input type='checkbox' checked=selectedIsVerified}}</li>
+        {{/if}}
       </ul>
 
     {{else}}
@@ -44,7 +52,14 @@
         <li class='list-group-item'>Age: {{imageSet.age}}</li>
         <li class='list-group-item'>Lat/Long: {{imageSet.latitude}} x {{imageSet.longitude}}</li>
         <li class='list-group-item lg-image-set-editor-gender'>Gender: {{imageSet.gender}}</li>
-        <li class='list-group-item'>Is Verified: {{imageSet.isVerified}}</li>
+        {{#if imageSet.lion}}
+          <li class='list-group-item'>Lion:
+            {{#link-to 'lion' imageSet.lion classNames='lg-lion-summary-link'}}
+              {{imageSet.lion.name}}
+            {{/link-to}}
+          </li>
+          <li class='list-group-item'>Is Verified: {{imageSet.isVerified}}</li>
+        {{/if}}
       </ul>
     {{/if}}
   </div>

--- a/app/templates/components/lg-selectable.hbs
+++ b/app/templates/components/lg-selectable.hbs
@@ -1,0 +1,3 @@
+<div {{action 'selectModel'}}>
+  {{yield}}
+</div>

--- a/app/templates/image-set/index.hbs
+++ b/app/templates/image-set/index.hbs
@@ -9,7 +9,7 @@
     {{#if model.cvRequest}}
       <div class='cv-request-pending'>CV Request Pending</div>
     {{else}}
-      <button class='btn btn-primary btn-large request-cv' {{action 'requestCv'}}
+      <button class='btn btn-primary btn-large request-cv' {{action 'requestCv' model}}
               type='button'>
         Request CV
       </button>

--- a/app/templates/image-sets/index.hbs
+++ b/app/templates/image-sets/index.hbs
@@ -1,6 +1,52 @@
 <h2>Image Sets for {{currentOrganization.name}}</h2>
-{{#if model}}
-  {{#each model as |imageSet|}}
-    {{lg-image-set-summary imageSet=imageSet}}
-  {{/each}}
-{{/if}}
+
+{{lg-lion-search action='displayResults' searchModel='imageSet' organizations=organizations store=store selectedOrganization=selectedOrganization}}
+
+<div class='container'>
+  <div class='row'>
+    <button type="button"
+            {{action 'requestCv' activeImageSet}}
+            {{bind-attr class=":btn :btn-primary canRequestCv::disabled :request-cv"}}>Run CV</button>
+    <button type="button"
+            {{action 'viewCv'}}
+            {{bind-attr class=":btn :btn-primary canViewCv::disabled :view-cv"}}>View CV</button>
+    <button type="button"
+            {{action 'viewImageSet'}}
+            {{bind-attr class=":btn :btn-primary canView::disabled :view-image-set"}}>View/Edit</button>
+    <button type="button"
+            {{action 'deleteImageSet'}}
+            {{bind-attr class=":btn :btn-danger canDelete::disabled :delete"}}>Delete</button>
+  </div>
+</div>
+<hr>
+<div class='container'>
+  <div class='panel panel-default'>
+    <div class='panel-heading'>
+      <div class='row'>
+        <div class='col-sm-2'>ID</div>
+        <div class='col-sm-2'>Name</div>
+        <div class='col-sm-2'>Age</div>
+        <div class='col-sm-2'>Org</div>
+        <div class='col-sm-2'>Status</div>
+      </div>
+    </div>
+
+    {{#if model}}
+      {{#each model as |imageSet|}}
+        {{#lg-selectable model=imageSet activeModel=activeImageSet action='selectImageSet' classNames="row"}}
+
+          <div class='col-sm-2 image-set-id'>{{imageSet.id}}</div>
+          <div class='col-sm-2'>
+            {{#if imageSet.lion}}
+              {{imageSet.lion.name}}
+            {{/if}}
+          </div>
+          <div class='col-sm-2'>{{imageSet.age}}</div>
+          <div class='col-sm-2'>{{imageSet.uploadingOrganization.name}}</div>
+          <div class='col-sm-2'>{{imageSet.status}}</div>
+
+        {{/lg-selectable}}
+      {{/each}}
+    {{/if}}
+  </div>
+</div>

--- a/app/templates/lions/search.hbs
+++ b/app/templates/lions/search.hbs
@@ -1,5 +1,5 @@
 <h2>Lion Search</h2>
-{{lg-lion-search action='search' organizations=organizations}}
+{{lg-lion-search action='displayResults' organizations=organizations store=store}}
 
 {{#if model}}
   <h3>Results</h3>

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -50,7 +50,8 @@
     "currentPath",
     "currentRouteName",
     "signIn",
-    "redirectsToLogin"
+    "redirectsToLogin",
+    "signInAndVisit"
   ],
   "node": false,
   "browser": false,

--- a/tests/acceptance/image-set-test.js
+++ b/tests/acceptance/image-set-test.js
@@ -27,8 +27,7 @@ test('visiting /image-set with no current user', function() {
 });
 
 test('visiting /image-set', function() {
-  signIn();
-  visit('/image-set/24');
+  signInAndVisit('/image-set/24');
 
   andThen(function() {
     equal(currentPath(), 'image-set.index');

--- a/tests/acceptance/image-set/cv-request-test.js
+++ b/tests/acceptance/image-set/cv-request-test.js
@@ -22,10 +22,9 @@ module('Acceptance: ImageSetCvRequest', {
 });
 
 test('visiting /image-set/24 and requesting CV', function() {
-  signIn();
   expect(3);
 
-  visit('/image-set/24');
+  signInAndVisit('/image-set/24');
 
   stubRequest('post', '/cvRequests', function(request) {
     ok(true, 'cv request post api called');
@@ -47,7 +46,6 @@ test('visiting /image-set/24 and requesting CV', function() {
 });
 
 test('visiting /image-set/24 and seeing request pending', function() {
-  signIn();
   expect(1);
 
   imageSetJSON.cv_request_id = '1';
@@ -59,7 +57,7 @@ test('visiting /image-set/24 and seeing request pending', function() {
     });
   });
 
-  visit('/image-set/24');
+  signInAndVisit('/image-set/24');
 
   andThen(function() {
     expectElement('.cv-request-pending');

--- a/tests/acceptance/image-set/cv-results-test.js
+++ b/tests/acceptance/image-set/cv-results-test.js
@@ -33,8 +33,7 @@ test('visiting /image-set/cv-results with no currentuser', function() {
 });
 
 test('visiting /image-set/cv-results', function() {
-  signIn();
-  visit('/image-set/25/cv-results');
+  signInAndVisit('/image-set/25/cv-results');
 
   andThen(function() {
     equal(currentPath(), 'image-set.cv-results');
@@ -50,8 +49,7 @@ test('visiting /image-set/cv-results', function() {
 test('visiting /image-set/cv-results and creating new lion', function() {
   expect(3);
 
-  signIn();
-  visit('/image-set/25/cv-results');
+  signInAndVisit('/image-set/25/cv-results');
 
   stubRequest('post', '/lions', function(){
     ok(true, 'lion create api called');
@@ -92,8 +90,7 @@ test('visiting /image-set/cv-results and creating new lion', function() {
 test('visiting /image-set/cv-results and associating with lion', function() {
   expect(3);
 
-  signIn();
-  visit('/image-set/25/cv-results');
+  signInAndVisit('/image-set/25/cv-results');
 
   stubGetUser();
   stubRequest('put', '/imageSets/25', function(){
@@ -117,8 +114,6 @@ test('visiting /image-set/cv-results and associating with lion', function() {
 });
 
 test('visiting /image-set/cv-results, cvResult associated with lion doesnt give option to change', function() {
-  signIn();
-
   // imageSet 24 is already associated with a lion
   stubGetCvResults('24');
   stubRequest('get', 'imageSets/:image_set_id', function(request){
@@ -126,7 +121,7 @@ test('visiting /image-set/cv-results, cvResult associated with lion doesnt give 
     return this.success(imageSetJSON);
   });
 
-  visit('/image-set/24/cv-results');
+  signInAndVisit('/image-set/24/cv-results');
 
   andThen(function() {
     equal(currentPath(), 'image-set.cv-results');

--- a/tests/acceptance/image-sets-test.js
+++ b/tests/acceptance/image-sets-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
-import { stubGetOrganizations, stubGetImageSets } from '../helpers/fake-requests';
+import { stubGetOrganizations, stubGetImageSets, stubCvResultJSON, stubGetImageSetsWithCvResults } from '../helpers/fake-requests';
 import { stubRequest } from '../helpers/fake-server';
 
 var application;
@@ -17,16 +17,25 @@ module('Acceptance: ImageSets', {
 });
 
 test('visiting /image-sets', function() {
-  signIn();
-  visit('/image-sets');
+  signInAndVisit('/image-sets');
 
   andThen(function() {
     equal(currentPath(), 'image-sets.index');
-    expectComponent('lg-image-set-summary');
+    expectComponent('lg-lion-search');
+    expectComponent('lg-selectable');
+    expectElement('.image-set-id');
+
+    expectNoElement('.row.active');
+    expectElement('.view-image-set.disabled');
   });
 
   andThen(function() {
-    click('.lg-image-set-summary-link');
+    click('.image-set-id');
+  });
+
+  andThen(function() {
+    expectElement('.row.active');
+    click('button.view-image-set');
   });
 
   andThen(function() {
@@ -35,33 +44,103 @@ test('visiting /image-sets', function() {
 });
 
 test('delete /image-set/:id', function() {
-  expect(5);
+  expect(7);
 
   stubRequest('delete', '/imageSets/24', function(request){
     ok(true, 'delete api was called');
     return this.noContent(204);
   });
 
-  signIn();
-  visit('/image-sets');
+  signInAndVisit('/image-sets');
 
   andThen(function() {
     equal(currentPath(), 'image-sets.index');
-    expectComponent('lg-image-set-summary');
-    expect('.image-set-summary:contains(24)', 1);
+    expect('.image-set-id:contains(24)', 1);
+    expectElement('button.delete.disabled');
   });
 
   andThen(function() {
-    click('.lg-image-set-summary-link');
+    click('.image-set-id');
   });
 
   andThen(function() {
-    equal(currentURL(), '/image-set/24');
-    click('.image-set-save-or-delete button:last-child');
+    expectElement('button.delete');
+    expectNoElement('button.delete.disabled');
+    expectElement('.row.active');
+    click('button.delete');
   });
 
   andThen(function() {
     equal(currentURL(), '/image-sets');
-    expect('.image-set-summary:contains(24)', 0);
+    expect('.image-set-id:contains(24)', 0);
+  });
+});
+
+test('view cv results', function() {
+  expect(8);
+
+  stubGetImageSetsWithCvResults();
+
+  stubRequest('get', '/cvResults', function(request) {
+    deepEqual(request.queryParams, {image_set_id: '24'});
+    ok(true, 'cv-results api called');
+    return this.success({
+      _embedded: {
+        cv_results: [
+          stubCvResultJSON()
+        ]
+      }
+    });
+  });
+
+  signInAndVisit('/image-sets');
+
+  andThen(function() {
+    equal(currentPath(), 'image-sets.index');
+    expect('.image-set-id:contains(24)', 1);
+    expectElement('button.view-cv.disabled');
+  });
+
+  andThen(function() {
+    click('.image-set-id');
+  });
+
+  andThen(function() {
+    expectElement('button.view-cv');
+    expectNoElement('button.view-cv.disabled');
+    expectElement('.row.active');
+    click('button.view-cv');
+  });
+
+  andThen(function() {
+    equal(currentURL(), '/image-set/24/cv-results');
+  });
+});
+
+test('test request CV', function() {
+  expect(6);
+
+  stubRequest('post', '/cvRequests', function(request){
+    ok(true, 'cv request post api was called');
+    return this.noContent(201);
+  });
+
+  signInAndVisit('/image-sets');
+
+  andThen(function() {
+    equal(currentPath(), 'image-sets.index');
+    expect('.image-set-id:contains(24)', 1);
+    expectElement('button.request-cv.disabled');
+  });
+
+  andThen(function() {
+    click('.image-set-id');
+  });
+
+  andThen(function() {
+    expectElement('button.request-cv');
+    expectNoElement('button.request-cv.disabled');
+    expectElement('.row.active');
+    click('button.request-cv');
   });
 });

--- a/tests/acceptance/lion-test.js
+++ b/tests/acceptance/lion-test.js
@@ -61,8 +61,7 @@ test('visiting /lion/2 with no current user', function() {
 });
 
 test('visiting /lion/2', function() {
-  signIn();
-  visit('/lion/2');
+  signInAndVisit('/lion/2');
 
   andThen(function() {
     equal(currentPath(), 'lion.index');

--- a/tests/acceptance/lions/search-test.js
+++ b/tests/acceptance/lions/search-test.js
@@ -22,8 +22,7 @@ test('visiting /lions/search with no current user', function() {
 });
 
 test('visiting /lions/search', function() {
-  signIn();
-  visit('/lions/search');
+  signInAndVisit('/lions/search');
 
   andThen(function() {
     equal(currentPath(), 'lions.search');
@@ -47,8 +46,7 @@ test('visiting /lions/search', function() {
 test('searching', function() {
   expect(1);
 
-  signIn();
-  visit('/lions/search');
+  signInAndVisit('/lions/search');
 
   stubRequest('get', '/lions', function(request){
 

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -79,8 +79,7 @@ test(`visit ${url} posts data to create token`, () => {
 });
 
 test(`visit ${url} while logged in redirects to dashboard`, () => {
-  signIn();
-  visit(url);
+  signInAndVisit(url);
   andThen( () => {
     equal(currentPath(), 'dashboard');
   });

--- a/tests/helpers/fake-requests.js
+++ b/tests/helpers/fake-requests.js
@@ -90,6 +90,20 @@ function stubGetImageSets() {
   });
 }
 
+function stubGetImageSetsWithCvResults() {
+  stubRequest('get', '/imageSets', function(request){
+    var json = stubImageSetJSON();
+    json.hasCvResults = true;
+    return this.success({
+      _embedded: {
+        image_sets: [
+          json
+        ]
+      }
+    });
+  });
+}
+
  function stubGetImageSet() {
   stubRequest('get', '/imageSets/24', function(request){
     return this.success(stubImageSetJSON());
@@ -137,7 +151,9 @@ export {
   stubGetOrganizations,
   stubGetImageSets,
   stubGetImageSet,
+  stubGetImageSetsWithCvResults,
   stubImageSetJSON,
   stubGetCvResults,
+  stubCvResultJSON,
   stubGetUser
 };

--- a/tests/helpers/sign-in.js
+++ b/tests/helpers/sign-in.js
@@ -7,7 +7,7 @@ Ember.Test.registerAsyncHelper('signIn', function(app){
   Ember.run(function(){
     var store = app.__container__.lookup('store:main');
     var organization = store.push('organization', {
-      id: 'org1',
+      id: '1',
       name: 'Organization 1'
     });
 
@@ -26,4 +26,10 @@ Ember.Test.registerAsyncHelper('redirectsToLogin', function(app, path){
   andThen(function() {
     equal(currentPath(), 'login');
   });
+});
+
+
+Ember.Test.registerAsyncHelper('signInAndVisit', function(app, path){
+  signIn();
+  visit(path);
 });

--- a/tests/unit/components/lg-selectable-test.js
+++ b/tests/unit/components/lg-selectable-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('lg-selectable', 'LgSelectable', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function() {
+  expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  equal(component._state, 'preRender');
+
+  // appends the component to the page
+  this.append();
+  equal(component._state, 'inDOM');
+});


### PR DESCRIPTION
@bantic  For you CC @redyaffle 

DO NOT MERGE. This will need a rebase after merging the google maps branch. But it is tested and ready for a review.

Main feature is an Image Set Index page which is more in line with the specs. Has a search field and a simple list of image sets with an active image set and actions at the top. I created a reusable `lg-selectable` component for this type of thing, and refactored the `lg-lion-search` component so it can be pretty much re-used to search image-sets as well. @redyaffle  Would appreciate your help sprucing up the style here at some point.

Also I added some logic to the image-set page to show the lion name if available and only show the is-verified flag if there is a lon.

Here's what it looks like. This requires the `image-set-search` API branch which has a separate [open PR](https://github.com/201-created/LG-api/pull/10)

![](http://g.recordit.co/CDZGMYZU3M.gif)
