### PR TITLE
Lion search in image set

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -32,9 +32,10 @@ export default HalAdapter.extend({
         });
 
         return new DS.InvalidError(errors);
+      } else {
+        return error;
       }
-    }
-    else {
+    } else {
       return error;
     }
   }

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,3 +1,5 @@
+import Ember from 'ember';
+import DS from 'ember-data';
 import HalAdapter from 'ember-data-hal-9000/adapter';
 import storage from '../utils/storage';
 import config from "../config/environment";
@@ -15,5 +17,25 @@ export default HalAdapter.extend({
     }
 
     return headers;
-  }.property().volatile()
+  }.property().volatile(),
+
+  ajaxError: function(jqXHR) {
+    var error = this._super(jqXHR);
+    if (jqXHR && jqXHR.status === 422) {
+      var response = Ember.$.parseJSON(jqXHR.responseText),
+          errors = {};
+
+      if (response.errors) {
+        var jsonErrors = response.errors;
+        Ember.keys(jsonErrors).forEach(function(key) {
+          errors[Ember.String.camelize(key)] = key + ' ' + jsonErrors[key];
+        });
+
+        return new DS.InvalidError(errors);
+      }
+    }
+    else {
+      return error;
+    }
+  }
 });

--- a/app/components/lg-cv-result-summary.js
+++ b/app/components/lg-cv-result-summary.js
@@ -2,13 +2,5 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   classNames: ['lg-cv-result-summary'],
-  cvResult: null,
-  action: null,
-
-  actions: {
-    selectCvResult: function() {
-      var cvResult = this.get('cvResult');
-      this.sendAction('action', cvResult);
-    }
-  }
+  cvResult: null
 });

--- a/app/components/lg-image-controller.js
+++ b/app/components/lg-image-controller.js
@@ -1,0 +1,50 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: 'span',
+  image: null,
+  editingEnabled: null,
+  imageTypes: [],
+
+  selectedIsPublic: Ember.computed.reads('image.isPublic'),
+  selectedImageType: Ember.computed.reads('image.imageType'),
+
+  // Image set must have at least 1 image
+  canDelete: Ember.computed.gt('image.imageSet.images.length', 1),
+
+  canMakeMain: function() {
+    var isMainImage = this.get('image.isMainImage'),
+        isPublic = this.get('image.isPublic');
+
+    return isPublic && !isMainImage;
+  }.property('image.isMainImage', 'image.isPublic'),
+
+  updateImageSet: function() {
+    var selectedIsPublic = this.get('selectedIsPublic'),
+        selectedImageType =this.get('selectedImageType'),
+        isPublic = this.get('image.isPublic'),
+        imageType = this.get('image.imageType');
+
+    if (selectedIsPublic !== isPublic || selectedImageType !== imageType) {
+      var image = this.get('image');
+      image.setProperties({
+        isPublic: selectedIsPublic,
+        imageType: selectedImageType
+      });
+
+      this.sendAction('saveImageSet');
+    }
+  }.observes('selectedIsPublic', 'selectedImageType'),
+
+  actions: {
+    makeMainImage: function() {
+      var image = this.get('image');
+      this.sendAction('makeMainImage', image);
+    },
+
+    deleteImage: function() {
+      var image = this.get('image');
+      this.sendAction('deleteImage', image);
+    }
+  }
+});

--- a/app/components/lg-image-gallery.js
+++ b/app/components/lg-image-gallery.js
@@ -9,6 +9,13 @@ export default Ember.Component.extend({
   isVisible: Ember.computed.gt('imageSet.images.length', 0),
 
   actions: {
+    saveImageSet: function() {
+      var imageSet = this.get('imageSet');
+      if (imageSet.get('id')) {
+        imageSet.save();
+      }
+    },
+
     makeMainImage: function(image) {
       var imageSet = this.get('imageSet');
       imageSet.set('mainImage', image);

--- a/app/components/lg-lion-associator.js
+++ b/app/components/lg-lion-associator.js
@@ -1,0 +1,33 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  imageSet: null,
+  activeLion: null,
+  activeImageSet: null,
+  lionName: null,
+  showLionNameField: false,
+
+  showAssociateButton: function(){
+    // Show button if imageSet is not already
+    // associated with a lion and there is an
+    // activeLion available.
+    var activeLion = this.get('activeLion'),
+        lion = this.get('imageSet.lion');
+
+    return activeLion && !lion;
+  }.property('activeLion', 'imageSet.lion'),
+
+  actions: {
+    toggleShowLionName: function() {
+      this.toggleProperty('showLionNameField');
+    },
+
+    associate: function(imageSet, activeLion) {
+      this.sendAction('associate', imageSet, activeLion);
+    },
+
+    createLion: function(imageSet, lionName) {
+      this.sendAction('createLion', imageSet, lionName);
+    }
+  }
+});

--- a/app/components/lg-status-error.js
+++ b/app/components/lg-status-error.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  model: null,
+  prefix: ''
+});

--- a/app/controllers/image-set.js
+++ b/app/controllers/image-set.js
@@ -7,6 +7,11 @@ export default Ember.Controller.extend({
   uploadIsPublic: false,
   organizations: null,
 
+  // If creating a new lion from an imageSet,
+  // this property will be set to the new lion record
+  // used mainly for showing saving status and errors
+  newLion: null,
+
   actions: {
     addImage: function(upload){
       var url = upload.get('url'),

--- a/app/controllers/image-set/cv-results.js
+++ b/app/controllers/image-set/cv-results.js
@@ -3,56 +3,13 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   imageSet: null,
   activeCvResult: null,
-  lionName: null,
-  showLionNameField: false,
 
-  showAssociateButton: function(){
-    // Show button if there is an activeCvResult
-    // and it has not yet been associated with a lion
-    var activeCvResult = this.get('activeCvResult'),
-        lion = this.get('imageSet.lion');
-
-    return activeCvResult && !lion;
-  }.property('activeCvResult', 'imageSet.lion'),
+  activeImageSet: Ember.computed.alias('activeCvResult.imageSet'),
+  activeLion: Ember.computed.alias('activeCvResult.lion'),
 
   actions: {
     setActiveCvResult: function(cvResult) {
       this.set('activeCvResult', cvResult);
-    },
-
-    associate: function(cvResult) {
-      var lion = cvResult.get('lion'),
-          imageSet = this.get('imageSet'),
-          controller = this;
-
-      imageSet.setProperties({
-        lion: lion,
-        isVerified: false
-      });
-
-      imageSet.save().then(function() {
-        controller.transitionToRoute('lion', lion);
-      });
-    },
-
-    toggleShowLionName: function() {
-      this.toggleProperty('showLionNameField');
-    },
-
-    createLion: function(){
-      var imageSet = this.get('imageSet'),
-          lionName = this.get('lionName'),
-          controller = this;
-
-      var lion = this.store.createRecord('lion', {
-        primaryImageSet: imageSet,
-        name: lionName
-      });
-
-      lion.save().then(function(lion){
-        controller.set('showLionNameField', false);
-        controller.transitionToRoute('lion', lion);
-      });
     }
   }
 });

--- a/app/controllers/image-set/lion-search.js
+++ b/app/controllers/image-set/lion-search.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  imageSet: null,
+  activeLion: null,
+
+  actions: {
+    displayResults: function(imageSets) {
+      this.set('model', imageSets);
+    },
+
+    selectLion: function(lion) {
+      this.set('activeLion', lion);
+    }
+  }
+});

--- a/app/controllers/lions/search.js
+++ b/app/controllers/lions/search.js
@@ -2,10 +2,21 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   organizations: null,
+  activeLion: null,
 
   actions: {
     displayResults: function(lions) {
       this.set('model', lions);
+    },
+
+    selectLion: function(lion) {
+      this.set('activeLion', lion);
+    },
+
+    viewLion: function(lion) {
+      if (lion) {
+        this.transitionToRoute('lion', lion);
+      }
     }
   }
 });

--- a/app/models/image.js
+++ b/app/models/image.js
@@ -4,5 +4,10 @@ export default DS.Model.extend({
   url: DS.attr('string'),
   isPublic: DS.attr('boolean'),
   imageType: DS.attr('string'),
-  imageSet: DS.belongsTo('image-set', {inverse: 'images'})
+  imageSet: DS.belongsTo('image-set', {inverse: 'images'}),
+
+  isMainImage: function() {
+    var imageSet = this.get('imageSet');
+    return imageSet && imageSet.get('mainImage') === this;
+  }.property('imageSet', 'imageSet.mainImage')
 });

--- a/app/router.js
+++ b/app/router.js
@@ -17,6 +17,7 @@ Router.map(function() {
 
   this.resource('image-set', { path: '/image-set/:image_set_id' }, function() {
     this.route("cv-results");
+    this.route("lion-search");
   });
 
   this.resource("lions", function() {

--- a/app/routes/image-set.js
+++ b/app/routes/image-set.js
@@ -19,7 +19,9 @@ export default Ember.Route.extend( OrganizationRouteMixin, RequireUserMixin, {
 
   actions: {
     associate: function(imageSet, lion) {
-      var route = this;
+      var route = this,
+          previousIsVerified = imageSet.get('isVerified');
+
       imageSet.setProperties({
         lion: lion,
         isVerified: false
@@ -27,6 +29,11 @@ export default Ember.Route.extend( OrganizationRouteMixin, RequireUserMixin, {
 
       imageSet.save().then(function() {
         route.transitionTo('lion', lion);
+      }, function(){
+        imageSet.setProperties({
+          lion: null,
+          isVerified: previousIsVerified
+        });
       });
     },
 
@@ -44,6 +51,8 @@ export default Ember.Route.extend( OrganizationRouteMixin, RequireUserMixin, {
 
       lion.save().then(function(lion){
         route.transitionTo('lion', lion);
+      }, function(){
+        //error shown in template
       });
     }
   }

--- a/app/routes/image-set.js
+++ b/app/routes/image-set.js
@@ -15,5 +15,32 @@ export default Ember.Route.extend( OrganizationRouteMixin, RequireUserMixin, {
 
   model: function(params) {
     return this.store.find('imageSet', params.image_set_id);
+  },
+
+  actions: {
+    associate: function(imageSet, lion) {
+      var route = this;
+      imageSet.setProperties({
+        lion: lion,
+        isVerified: false
+      });
+
+      imageSet.save().then(function() {
+        route.transitionTo('lion', lion);
+      });
+    },
+
+    createLion: function(imageSet, lionName){
+      var route = this;
+
+      var lion = this.store.createRecord('lion', {
+        primaryImageSet: imageSet,
+        name: lionName
+      });
+
+      lion.save().then(function(lion){
+        route.transitionTo('lion', lion);
+      });
+    }
   }
 });

--- a/app/routes/image-set.js
+++ b/app/routes/image-set.js
@@ -38,6 +38,10 @@ export default Ember.Route.extend( OrganizationRouteMixin, RequireUserMixin, {
         name: lionName
       });
 
+      // Bind lion to controller so that we can show errors
+      var controller = this.get('controller');
+      controller.set('newLion', lion);
+
       lion.save().then(function(lion){
         route.transitionTo('lion', lion);
       });

--- a/app/routes/image-set.js
+++ b/app/routes/image-set.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import DS from 'ember-data';
 import config from '../config/environment';
 import OrganizationRouteMixin from 'lion-guardians/mixins/organization-route';
 import RequireUserMixin from 'lion-guardians/mixins/require-user';
@@ -29,11 +30,15 @@ export default Ember.Route.extend( OrganizationRouteMixin, RequireUserMixin, {
 
       imageSet.save().then(function() {
         route.transitionTo('lion', lion);
-      }, function(){
+      }, function(error){
         imageSet.setProperties({
           lion: null,
           isVerified: previousIsVerified
         });
+
+        if (!(error instanceof DS.InvalidError)) {
+          alert("There was an error saving");
+        }
       });
     },
 
@@ -51,8 +56,10 @@ export default Ember.Route.extend( OrganizationRouteMixin, RequireUserMixin, {
 
       lion.save().then(function(lion){
         route.transitionTo('lion', lion);
-      }, function(){
-        //error shown in template
+      }, function(error){
+        if (!(error instanceof DS.InvalidError)) {
+          alert("There was an error saving");
+        }
       });
     }
   }

--- a/app/routes/image-set/lion-search.js
+++ b/app/routes/image-set/lion-search.js
@@ -1,0 +1,25 @@
+import Ember from 'ember';
+import OrganizationRouteMixin from 'lion-guardians/mixins/organization-route';
+
+export default Ember.Route.extend(OrganizationRouteMixin, {
+  model: function() {
+    // Model will be populated after searching,
+    // in displayResults action on controller.
+    return [];
+  },
+
+  setupController: function(controller) {
+    var imageSet = this.modelFor('imageSet');
+    controller.setProperties({
+      imageSet: imageSet
+    });
+  },
+
+  resetController: function(controller) {
+    controller.setProperties({
+      model: [],
+      activeLion: null
+    });
+  }
+
+});

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -133,3 +133,13 @@ body > .ember-view {
 .row.active {
   color: red
 }
+
+.error {
+  border: 1px solid red;
+  color: red;
+}
+
+.status-message {
+  border: 1px solid green;
+  color: green;
+}

--- a/app/templates/components/lg-cv-result-summary.hbs
+++ b/app/templates/components/lg-cv-result-summary.hbs
@@ -1,12 +1,10 @@
 <li class='list-group-item'>
-  <a class='select-cv-result' href='#' {{action 'selectCvResult'}}>
-    {{#if cvResult.lion}}
-      Lion: {{cvResult.lion.name}}
-    {{else}}
-      {{#if cvResult.imageSet}}
-        Image Set: {{cvResult.imageSet.id}}
-      {{/if}}
+  {{#if cvResult.lion}}
+    Lion: {{cvResult.lion.name}}
+  {{else}}
+    {{#if cvResult.imageSet}}
+      Image Set: {{cvResult.imageSet.id}}
     {{/if}}
-    {{cvResult.percent}} %
-  </a>
+  {{/if}}
+  {{cvResult.percent}} %
 </li>

--- a/app/templates/components/lg-image-controller.hbs
+++ b/app/templates/components/lg-image-controller.hbs
@@ -1,0 +1,38 @@
+<div class='image-gallery-image'>
+  <img {{bind-attr src=image.url}}>
+
+  <div class='image-properties'>
+    {{#if editingEnabled}}
+      {{view 'select' class='form-control' content=imageTypes value=selectedImageType}}
+      <div class='public-private checkbox'>
+        {{input type='checkbox' checked=selectedIsPublic disabled=image.isMainImage}} Public
+      </div>
+      {{#if image.id}}
+        <button
+          {{bind-attr class=":btn :btn-xs image.isMainImage:btn-success:btn-warning canMakeMain::disabled"}}
+          {{action 'makeMainImage'}}>
+          {{#if image.isMainImage}}
+            Main
+          {{else}}
+            Make Main
+          {{/if}}
+        </button>
+      {{/if}}
+      <button
+        {{bind-attr class=":btn :btn-xs :btn-danger canDelete::disabled"}}
+        {{action 'deleteImage'}}>
+        Delete
+      </button>
+
+    {{else}}
+      <li>{{image.imageType}}</li>
+      <li>
+        {{#if image.isPublic}}
+          Public
+          {{else}}
+          Private
+        {{/if}}
+      </li>
+    {{/if}}
+  </div>
+</div>

--- a/app/templates/components/lg-image-gallery.hbs
+++ b/app/templates/components/lg-image-gallery.hbs
@@ -5,36 +5,13 @@
 
   <div class='scrollable-gallery'>
     {{#each imageSet.images as |image|}}
-      <div class='image-gallery-image'>
-        <img {{bind-attr src=image.url}}>
-
-        <div class='image-properties'>
-          {{#if editingEnabled}}
-            {{view 'select' class='form-control' content=imageTypes value=image.imageType}}
-            <div class='public-private checkbox'>
-              {{input type='checkbox' checked=image.isPublic}} Public
-            </div>
-            {{#if image.id}}
-              <button class='btn btn-xs btn-warning' {{action 'makeMainImage' image}}>
-                Make Main Image
-              </button>
-            {{/if}}
-            <button class='btn btn-xs btn-danger' {{action 'deleteImage' image}}>
-              Delete Image
-            </button>
-
-          {{else}}
-            <li>{{image.imageType}}</li>
-            <li>
-              {{#if image.isPublic}}
-                Public
-              {{else}}
-                Private
-              {{/if}}
-            </li>
-          {{/if}}
-        </div>
-      </div>
+      {{lg-image-controller image=image
+        imageTypes=imageTypes
+        editingEnabled=editingEnabled
+        makeMainImage='makeMainImage'
+        deleteImage='deleteImage'
+        saveImageSet='saveImageSet'
+      }}
     {{/each}}
   </div>
   <div class='scroll-arrows'>

--- a/app/templates/components/lg-lion-associator.hbs
+++ b/app/templates/components/lg-lion-associator.hbs
@@ -1,0 +1,29 @@
+<div class='row'>
+  {{#unless imageSet.lion}}
+    {{#if showLionNameField}}
+      {{input type='text' name='lionName' placeholder='Lion Name' value=lionName}}
+      <button class='btn btn-xs btn-warning create-lion' {{action 'createLion' imageSet lionName}}>
+        Create Lion
+      </button>
+      <button class='btn btn-xs btn-warning' {{action 'toggleShowLionName'}}>
+        Cancel
+      </button>
+    {{else}}
+      <button class='btn btn-xs btn-warning start-create-lion' {{action 'toggleShowLionName'}}>
+        No Match - Create Lion
+      </button>
+    {{/if}}
+  {{/unless}}
+</div>
+
+<div class='row'>
+  {{#if showAssociateButton}}
+    <button class='btn btn-xs btn-warning associate-lion' {{action 'associate' imageSet activeLion}}>
+      Associate
+    </button>
+  {{/if}}
+</div>
+
+{{#if activeImageSet}}
+  {{lg-image-set-summary imageSet=activeImageSet}}
+{{/if}}

--- a/app/templates/components/lg-lion-summary.hbs
+++ b/app/templates/components/lg-lion-summary.hbs
@@ -3,9 +3,6 @@
     <div class='panel panel-default'>
       <div class='panel-heading'>
         {{lion.name}}
-        {{#link-to 'lion' lion classNames='lg-lion-summary-link'}}
-          View Details
-        {{/link-to}}
       </div>
       <ul class='list-group'>
         <li class='list-group-item'>Gender: {{lion.gender}}</li>

--- a/app/templates/components/lg-status-error.hbs
+++ b/app/templates/components/lg-status-error.hbs
@@ -1,0 +1,11 @@
+{{#if model.isSaving}}
+  <div class='status-message'>
+    {{prefix}} Saving In Progress...
+  </div>
+{{/if}}
+
+{{#each model.errors.messages as |error|}}
+  <div class='error'>
+    {{prefix}} {{error}}
+  </div>
+{{/each}}

--- a/app/templates/image-set.hbs
+++ b/app/templates/image-set.hbs
@@ -2,6 +2,12 @@
   <div class='image-set-title'>
     <h2>Image Set</h2>
   </div>
+
+  <div class='messages'>
+    {{lg-status-error model=model prefix='Image Set'}}
+    {{lg-status-error model=newLion prefix = 'Lion'}}
+  </div>
+
   <div class='image-set-save-or-delete'>
     <button class='btn btn-primary btn-large' type='button' {{action 'saveImageSet'}}>
       Save Image Set

--- a/app/templates/image-set/cv-results.hbs
+++ b/app/templates/image-set/cv-results.hbs
@@ -4,7 +4,11 @@
   <div class='col-sm-4'>
     <ul class='list-group'>
       {{#each model as |cvResult|}}
-        {{lg-cv-result-summary cvResult=cvResult action='setActiveCvResult'}}
+        {{#lg-selectable model=cvResult activeModel=activeCvResult
+          action='setActiveCvResult'
+          classNames='row'}}
+          {{lg-cv-result-summary cvResult=cvResult }}
+        {{/lg-selectable}}
       {{/each}}
     </ul>
   </div>

--- a/app/templates/image-set/cv-results.hbs
+++ b/app/templates/image-set/cv-results.hbs
@@ -10,35 +10,10 @@
   </div>
 
   <div class='col-sm-4'>
-    <div class='row'>
-      {{#unless imageSet.lion}}
-        {{#if showLionNameField}}
-          {{input type='text' name='lionName' placeholder='Lion Name' value=lionName}}
-          <button class='btn btn-xs btn-warning create-lion' {{action 'createLion'}}>
-            Create Lion
-          </button>
-          <button class='btn btn-xs btn-warning' {{action 'toggleShowLionName'}}>
-            Cancel
-          </button>
-        {{else}}
-          <button class='btn btn-xs btn-warning start-create-lion' {{action 'toggleShowLionName'}}>
-            No Match - Create Lion
-          </button>
-        {{/if}}
-      {{/unless}}
-    </div>
-
-    <div class='row'>
-      {{#if showAssociateButton}}
-        <button class='btn btn-xs btn-warning associate-lion' {{action 'associate' activeCvResult}}>
-          Associate
-        </button>
-      {{/if}}
-
-    </div>
-
-    {{#if activeCvResult}}
-      {{lg-image-set-summary imageSet=activeCvResult.imageSet}}
-    {{/if}}
+    {{lg-lion-associator activeLion=activeLion
+      activeImageSet=activeImageSet
+      imageSet=imageSet
+      createLion='createLion'
+      associate='associate'}}
   </div>
 </div>

--- a/app/templates/image-set/index.hbs
+++ b/app/templates/image-set/index.hbs
@@ -17,7 +17,7 @@
   {{/if}}
 
   {{#link-to 'image-set.lion-search' model}}
-    <button class='btn btn-primary btn-large' type='button'>
+    <button class='btn btn-primary btn-large lion-search-button' type='button'>
       Lion Search
     </button>
   {{/link-to}}

--- a/app/templates/image-set/index.hbs
+++ b/app/templates/image-set/index.hbs
@@ -15,6 +15,13 @@
       </button>
     {{/if}}
   {{/if}}
+
+  {{#link-to 'image-set.lion-search' model}}
+    <button class='btn btn-primary btn-large' type='button'>
+      Lion Search
+    </button>
+  {{/link-to}}
+
   <hr>
 </div>
 

--- a/app/templates/image-set/lion-search.hbs
+++ b/app/templates/image-set/lion-search.hbs
@@ -1,0 +1,24 @@
+<h3>Search Lions</h3>
+
+<div class='row'>
+  <div class='col-sm-4'>
+    {{lg-lion-search action='displayResults' organizations=organizations store=store}}
+
+    {{#if model}}
+      <h3>Results</h3>
+      {{#each model as |lion|}}
+        {{#lg-selectable model=lion activeModel=activeLion action='selectLion' classNames="row"}}
+          {{lg-lion-summary lion=lion}}
+        {{/lg-selectable}}
+      {{/each}}
+    {{/if}}
+
+  </div>
+  <div class='col-sm-4'>
+    {{lg-lion-associator activeLion=activeLion
+      activeImageSet=activeLion.primaryImageSet
+      imageSet=imageSet
+      createLion='createLion'
+      associate='associate'}}
+  </div>
+</div>

--- a/app/templates/image-sets/index.hbs
+++ b/app/templates/image-sets/index.hbs
@@ -1,6 +1,17 @@
 <h2>Image Sets for {{currentOrganization.name}}</h2>
 
-{{lg-lion-search action='displayResults' searchModel='imageSet' organizations=organizations store=store selectedOrganization=selectedOrganization}}
+<div class='row'>
+  <div class='col-md-4'>
+    {{lg-lion-search action='displayResults' searchModel='imageSet' organizations=organizations store=store selectedOrganization=selectedOrganization}}
+  </div>
+  <div class='col-md-4'>
+    {{#if activeImageSet.mainImage.url}}
+      <div class='image-thumbnail'>
+        <img {{bind-attr src=activeImageSet.mainImage.url}}>
+      </div>
+    {{/if}}
+  </div>
+</div>
 
 <div class='container'>
   <div class='row'>

--- a/app/templates/lions/search.hbs
+++ b/app/templates/lions/search.hbs
@@ -3,7 +3,15 @@
 
 {{#if model}}
   <h3>Results</h3>
+  <div class='row'>
+    <button type="button"
+            {{action 'viewLion' activeLion}}
+            {{bind-attr class=":btn :btn-primary :view-lion"}}>View/Edit</button>
+  </div>
+
   {{#each model as |lion|}}
-    {{lg-lion-summary lion=lion}}
+    {{#lg-selectable model=lion activeModel=activeLion action='selectLion' classNames="row"}}
+      {{lg-lion-summary lion=lion}}
+    {{/lg-selectable}}
   {{/each}}
 {{/if}}

--- a/app/utils/units.js
+++ b/app/utils/units.js
@@ -1,9 +1,9 @@
 var imageTypes = [
+  'cv',
   'full-body',
   'whisker',
-  'markings',
-  'cv',
-  'face'
+  'main-id',
+  'markings'
 ];
 
 var genders = [

--- a/tests/acceptance/image-set/cv-results-test.js
+++ b/tests/acceptance/image-set/cv-results-test.js
@@ -38,7 +38,7 @@ test('visiting /image-set/cv-results', function() {
   andThen(function() {
     equal(currentPath(), 'image-set.cv-results');
     expectComponent('lg-cv-result-summary');
-    click('.select-cv-result');
+    click('.lg-cv-result-summary');
   });
 
   andThen(function() {
@@ -70,7 +70,7 @@ test('visiting /image-set/cv-results and creating new lion', function() {
   });
 
   andThen(function() {
-    click('.select-cv-result');
+    click('.lg-cv-result-summary');
   });
 
   andThen(function() {
@@ -101,7 +101,7 @@ test('visiting /image-set/cv-results and associating with lion', function() {
   });
 
   andThen(function() {
-    click('.select-cv-result');
+    click('.lg-cv-result-summary');
   });
 
   andThen(function() {
@@ -126,7 +126,7 @@ test('visiting /image-set/cv-results, cvResult associated with lion doesnt give 
   andThen(function() {
     equal(currentPath(), 'image-set.cv-results');
     expectComponent('lg-cv-result-summary');
-    click('.select-cv-result');
+    click('.lg-cv-result-summary');
   });
 
   andThen(function() {

--- a/tests/acceptance/image-set/cv-results-test.js
+++ b/tests/acceptance/image-set/cv-results-test.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import startApp from '../../helpers/start-app';
 import { stubRequest } from '../../helpers/fake-server';
 import { stubGetCvResults,
+         stubGetImageSet,
          stubImageSetJSON,
          stubGetOrganizations,
          stubGetUser } from '../../helpers/fake-requests';
@@ -15,10 +16,7 @@ module('Acceptance: ImageSetCvResults', {
     imageSetJSON = stubImageSetJSON();
     imageSetJSON.id = 25;
 
-    stubRequest('get', 'imageSets/:image_set_id', function(request){
-      imageSetJSON.id = request.params.image_set_id;
-      return this.success(imageSetJSON);
-    });
+    stubGetImageSet();
 
     stubGetOrganizations();
     stubGetCvResults('25');
@@ -116,10 +114,6 @@ test('visiting /image-set/cv-results and associating with lion', function() {
 test('visiting /image-set/cv-results, cvResult associated with lion doesnt give option to change', function() {
   // imageSet 24 is already associated with a lion
   stubGetCvResults('24');
-  stubRequest('get', 'imageSets/:image_set_id', function(request){
-    imageSetJSON.id = request.params.image_set_id;
-    return this.success(imageSetJSON);
-  });
 
   signInAndVisit('/image-set/24/cv-results');
 

--- a/tests/acceptance/image-set/cv-results-test.js
+++ b/tests/acceptance/image-set/cv-results-test.js
@@ -42,7 +42,7 @@ test('visiting /image-set/cv-results', function() {
   });
 
   andThen(function() {
-    expectElement('.lg-image-set-summary');
+    expectComponent('lg-lion-associator');
   });
 });
 

--- a/tests/acceptance/image-set/lion-search-test.js
+++ b/tests/acceptance/image-set/lion-search-test.js
@@ -23,7 +23,7 @@ module('Acceptance: ImageSetLionSearch', {
 });
 
 test('visiting /image-set/lion-search', function() {
-  expect(6);
+  expect(9);
 
   signInAndVisit('/image-set/25');
   click('.lion-search-button');
@@ -41,21 +41,33 @@ test('visiting /image-set/lion-search', function() {
 
   andThen(function() {
     expectElement('.row.active');
-  });
 
-    andThen(function() {
+    stubRequest('put', '/imageSets/:image_set_id', function(){
+      ok(true, 'put update image set api called');
+      return this.error(422, {
+        errors: {lion: 'already associated with different lion'}
+      });
+    });
+
     click('button.associate-lion');
   });
 
-  stubRequest('put', 'imageSets/:image_set_id', function(request){
-    var json = stubImageSetJSON();
-    json.id = request.params.image_set_id;
-    json.lion_id = 2;
+  andThen(function() {
+    expectElement('div.error');
+    equal(find('div.error').last().text().trim(), "Image Set lion already associated with different lion");
 
-    ok(true, 'put update image set api called');
-    json.lion_id = 2;
+    stubRequest('put', 'imageSets/:image_set_id', function(request){
+      var json = stubImageSetJSON();
+      json.id = request.params.image_set_id;
+      json.lion_id = 2;
 
-    return this.success(json);
+      ok(true, 'put update image set api called');
+      json.lion_id = 2;
+
+      return this.success(json);
+    });
+
+    click('button.associate-lion');
   });
 
   andThen(function() {

--- a/tests/acceptance/image-set/lion-search-test.js
+++ b/tests/acceptance/image-set/lion-search-test.js
@@ -1,0 +1,64 @@
+import Ember from 'ember';
+import startApp from '../../helpers/start-app';
+import {stubRequest} from '../../helpers/fake-server.js';
+import { stubGetImageSet,
+         stubGetOrganizations,
+         stubImageSetJSON,
+         stubGetUser,
+         stubGetLions } from '../../helpers/fake-requests';
+
+var application;
+
+module('Acceptance: ImageSetLionSearch', {
+  setup: function() {
+    application = startApp();
+    stubGetOrganizations();
+    stubGetLions();
+    stubGetImageSet(25);
+    stubGetUser();
+  },
+  teardown: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('visiting /image-set/lion-search', function() {
+  expect(6);
+
+  signInAndVisit('/image-set/25');
+  click('.lion-search-button');
+
+  andThen(function() {
+    equal(currentPath(), 'image-set.lion-search');
+    click('.lion-search');
+  });
+
+  andThen(function() {
+    expectComponent('lg-lion-summary');
+    expectNoElement('.row.active');
+    click('.lg-lion-summary');
+  });
+
+  andThen(function() {
+    expectElement('.row.active');
+  });
+
+    andThen(function() {
+    click('button.associate-lion');
+  });
+
+  stubRequest('put', 'imageSets/:image_set_id', function(request){
+    var json = stubImageSetJSON();
+    json.id = request.params.image_set_id;
+    json.lion_id = 2;
+
+    ok(true, 'put update image set api called');
+    json.lion_id = 2;
+
+    return this.success(json);
+  });
+
+  andThen(function() {
+    equal(currentURL(), '/lion/2');
+  });
+});

--- a/tests/acceptance/image-sets-test.js
+++ b/tests/acceptance/image-sets-test.js
@@ -26,6 +26,7 @@ test('visiting /image-sets', function() {
     expectElement('.image-set-id');
 
     expectNoElement('.row.active');
+    expectNoElement('.image-thumbnail');
     expectElement('.view-image-set.disabled');
   });
 
@@ -35,6 +36,7 @@ test('visiting /image-sets', function() {
 
   andThen(function() {
     expectElement('.row.active');
+    expectElement('.image-thumbnail');
     click('button.view-image-set');
   });
 

--- a/tests/acceptance/lions/search-test.js
+++ b/tests/acceptance/lions/search-test.js
@@ -35,7 +35,11 @@ test('visiting /lions/search', function() {
 
   andThen(function() {
     expectComponent('lg-lion-summary', 1);
-    click('.lg-lion-summary-link');
+    click('.lg-lion-summary');
+  });
+
+  andThen(function() {
+    click('.view-lion');
   });
 
   andThen(function() {

--- a/tests/helpers/fake-requests.js
+++ b/tests/helpers/fake-requests.js
@@ -104,9 +104,12 @@ function stubGetImageSetsWithCvResults() {
   });
 }
 
- function stubGetImageSet() {
-  stubRequest('get', '/imageSets/24', function(request){
-    return this.success(stubImageSetJSON());
+function stubGetImageSet() {
+  stubRequest('get', 'imageSets/:image_set_id', function(request){
+    var json = stubImageSetJSON();
+    json.id = request.params.image_set_id;
+
+    return this.success(json);
   });
  }
 

--- a/tests/unit/components/lg-image-controller-test.js
+++ b/tests/unit/components/lg-image-controller-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('lg-image-controller', 'LgImageControllerComponent', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function() {
+  expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  equal(component._state, 'preRender');
+
+  // appends the component to the page
+  this.append();
+  equal(component._state, 'inDOM');
+});

--- a/tests/unit/components/lg-lion-associator-test.js
+++ b/tests/unit/components/lg-lion-associator-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('lg-lion-associator', 'LgLionAssociatorComponent', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function() {
+  expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  equal(component._state, 'preRender');
+
+  // appends the component to the page
+  this.append();
+  equal(component._state, 'inDOM');
+});

--- a/tests/unit/components/lg-status-error-test.js
+++ b/tests/unit/components/lg-status-error-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('lg-status-error', 'LgStatusErrorComponent', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function() {
+  expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  equal(component._state, 'preRender');
+
+  // appends the component to the page
+  this.append();
+  equal(component._state, 'inDOM');
+});

--- a/tests/unit/controllers/image-set/lion-search-test.js
+++ b/tests/unit/controllers/image-set/lion-search-test.js
@@ -1,0 +1,15 @@
+import {
+  moduleFor,
+  test
+} from 'ember-qunit';
+
+moduleFor('controller:image-set/lion-search', 'ImageSetLionSearchController', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function() {
+  var controller = this.subject();
+  ok(controller);
+});

--- a/tests/unit/routes/image-set/lion-search-test.js
+++ b/tests/unit/routes/image-set/lion-search-test.js
@@ -1,0 +1,14 @@
+import {
+  moduleFor,
+  test
+} from 'ember-qunit';
+
+moduleFor('route:image-set/lion-search', 'ImageSetLionSearchRoute', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function() {
+  var route = this.subject();
+  ok(route);
+});


### PR DESCRIPTION
@bantic  For you, CC @redyaffle 

Embedding the lion search below an image set so that users can search. We'll want to tweak the UI for this but the basic structure is there. I did a bunch of refactoring so that I could reuse code from cv-results as much as possible. Such as moving some actions up to the image-set route so that they can get called from either the cv-result or lion-search template.

Here's what it looks like
![](http://g.recordit.co/05fq6VMF3V.gif)
