### PR TITLE
add selectable image sets on lion page with actions

### DIFF
--- a/app/components/lg-selectable.js
+++ b/app/components/lg-selectable.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   model: null,
   activeModel: null,
-  classNames: [],
+  classNames: ['row'],
   classNameBindings: ["isActive:active"],
 
   isActive: function() {

--- a/app/controllers/lion.js
+++ b/app/controllers/lion.js
@@ -1,0 +1,48 @@
+import Ember from 'ember';
+import DS from 'ember-data';
+
+export default Ember.Controller.extend({
+  currentUser: null,
+  activeImageSet: null,
+
+  isOwner: function() {
+    return this.get('model.organization') === this.get('currentUser.organization');
+  }.property('model.organization', 'currentUser.organization'),
+
+  canMakePrimary: function() {
+    return this.get('activeImageSet') && this.get('isOwner');
+  }.property('activeImageSet', 'isOwner'),
+
+  actions: {
+    selectImageSet: function(imageSet) {
+      this.set('activeImageSet', imageSet);
+    },
+
+    viewImageSet: function() {
+      var imageSet = this.get('activeImageSet');
+      if (imageSet) {
+        this.transitionToRoute('image-set', imageSet);
+      }
+    },
+
+    makePrimaryImageSet: function() {
+      var imageSet = this.get('activeImageSet'),
+          lion = this.get('model'),
+          isOwner = this.get('isOwner'),
+          oldPrimary = lion.get('primaryImageSet');
+
+      if (isOwner && imageSet) {
+        lion.set('primaryImageSet', imageSet);
+
+        lion.save().then(function() {
+        }, function(error) {
+          lion.set('primaryImageSet', oldPrimary);
+
+          if (!(error instanceof DS.InvalidError)) {
+            alert("There was an error saving");
+          }
+        });
+      }
+    }
+  }
+});

--- a/app/routes/lion.js
+++ b/app/routes/lion.js
@@ -3,4 +3,12 @@ import OrganizationRouteMixin from 'lion-guardians/mixins/organization-route';
 import RequireUserMixin from 'lion-guardians/mixins/require-user';
 
 export default Ember.Route.extend(OrganizationRouteMixin, RequireUserMixin, {
+  setupController: function(controller, model) {
+    var currentUser = this.get('toriiSession.currentUser');
+
+    controller.setProperties({
+      model: model,
+      currentUser: currentUser
+    });
+  }
 });

--- a/app/templates/image-set/cv-results.hbs
+++ b/app/templates/image-set/cv-results.hbs
@@ -5,8 +5,7 @@
     <ul class='list-group'>
       {{#each model as |cvResult|}}
         {{#lg-selectable model=cvResult activeModel=activeCvResult
-          action='setActiveCvResult'
-          classNames='row'}}
+          action='setActiveCvResult'}}
           {{lg-cv-result-summary cvResult=cvResult }}
         {{/lg-selectable}}
       {{/each}}

--- a/app/templates/image-set/lion-search.hbs
+++ b/app/templates/image-set/lion-search.hbs
@@ -7,7 +7,7 @@
     {{#if model}}
       <h3>Results</h3>
       {{#each model as |lion|}}
-        {{#lg-selectable model=lion activeModel=activeLion action='selectLion' classNames="row"}}
+        {{#lg-selectable model=lion activeModel=activeLion action='selectLion'}}
           {{lg-lion-summary lion=lion}}
         {{/lg-selectable}}
       {{/each}}

--- a/app/templates/image-sets/index.hbs
+++ b/app/templates/image-sets/index.hbs
@@ -50,7 +50,7 @@
 
     {{#if model}}
       {{#each model as |imageSet|}}
-        {{#lg-selectable model=imageSet activeModel=activeImageSet action='selectImageSet' classNames="row"}}
+        {{#lg-selectable model=imageSet activeModel=activeImageSet action='selectImageSet'}}
 
           <div class='col-sm-2 image-set-id'>{{imageSet.id}}</div>
           <div class='col-sm-2'>

--- a/app/templates/lion.hbs
+++ b/app/templates/lion.hbs
@@ -1,4 +1,8 @@
-<h2>Lion {{model.name}}</h2>
+<h2>{{model.name}}</h2>
+
+<div class='messages'>
+  {{lg-status-error model=model prefix='Lion'}}
+</div>
 
 <div class='row'>
   {{lg-image-set-editor
@@ -10,9 +14,32 @@
 <hr>
 
 <h3>Image Sets</h3>
-{{#each model.imageSets as |imageSet|}}
+
+<div class='container'>
   <div class='row'>
-    <h4>Image Set {{imageSet.id}}</h4>
-    {{lg-image-gallery imageSet=imageSet editingEnabled=false}}
+    <button type="button"
+            {{action 'viewImageSet'}}
+            {{bind-attr class=":btn :btn-primary activeImageSet::disabled :view-image-set"}}>
+      View/Edit
+    </button>
+    <button type="button"
+            {{action 'makePrimaryImageSet'}}
+            {{bind-attr class=":btn :btn-primary canMakePrimary::disabled :make-primary"}}>
+      Make Primary
+    </button>
   </div>
+</div>
+
+{{#each model.imageSets as |imageSet|}}
+  {{#lg-selectable model=imageSet
+    activeModel=activeImageSet
+    action='selectImageSet'}}
+    <div class='row'>
+      <h4>Image Set {{imageSet.id}}</h4>
+      <div class='image-thumbnail'>
+        <img {{bind-attr src=imageSet.mainImage.url}}>
+      </div>
+      {{lg-image-gallery imageSet=imageSet editingEnabled=false}}
+    </div>
+  {{/lg-selectable}}
 {{/each}}

--- a/app/templates/lions/search.hbs
+++ b/app/templates/lions/search.hbs
@@ -6,11 +6,11 @@
   <div class='row'>
     <button type="button"
             {{action 'viewLion' activeLion}}
-            {{bind-attr class=":btn :btn-primary :view-lion"}}>View/Edit</button>
+            {{bind-attr class=":btn :btn-primary :view-lion activeLion::disabled"}}>View/Edit</button>
   </div>
 
   {{#each model as |lion|}}
-    {{#lg-selectable model=lion activeModel=activeLion action='selectLion' classNames="row"}}
+    {{#lg-selectable model=lion activeModel=activeLion action='selectLion'}}
       {{lg-lion-summary lion=lion}}
     {{/lg-selectable}}
   {{/each}}

--- a/tests/acceptance/lion-test.js
+++ b/tests/acceptance/lion-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import { stubRequest } from '../helpers/fake-server';
-import { stubGetOrganizations } from '../helpers/fake-requests';
+import { stubLionJSON, stubGetOrganizations } from '../helpers/fake-requests';
 
 var application;
 
@@ -12,43 +12,7 @@ module('Acceptance: Lion', {
     stubGetOrganizations();
 
     stubRequest('get', '/lions/2', function(request){
-      return this.success({
-        id: 2,
-        name: "Simba",
-        primary_image_set_id: 24,
-        _embedded: {
-          image_sets: [
-            {
-              id: 24,
-              is_verified: false,
-              latitude: null,
-              longitude: null,
-              gender: "male",
-              age: "24",
-              main_image_id: 49,
-              user_id: 1,
-              _embedded: {
-                images: [
-                  {
-                    id: 49,
-                    url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9YGARc5KB0XV+IAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAF1JREFUGNO9zL0NglAAxPEfdLTs4BZM4DIO4C7OwQg2JoQ9LE1exdlYvBBeZ7jqch9//q1uH4TLzw4d6+ErXMMcXuHWxId3KOETnnXXV6MJpcq2MLaI97CER3N0vr4MkhoXe0rZigAAAABJRU5ErkJggg==", // red dot
-                    image_type: "full-body",
-                    is_public: true
-                  }
-                ],
-                uploading_organization: {
-                  id: 1,
-                  name: "Lion Guardians"
-                }
-              }
-            }
-          ],
-          organization: {
-            id: 1,
-            name: "Lion Guardians"
-          }
-        }
-      });
+      return this.success(stubLionJSON());
     });
   },
   teardown: function() {
@@ -69,5 +33,35 @@ test('visiting /lion/2', function() {
 
     expectComponent('lg-image-set-editor');
     expectComponent('lg-image-gallery');
+
+    expectNoElement('.row.active');
+    click('.image-thumbnail');
+  });
+
+  andThen(function() {
+    expectElement('.row.active');
+    click('.view-image-set');
+  });
+
+  andThen(function() {
+    equal(currentURL(), '/image-set/24');
+  });
+});
+
+test('visiting /lion/2 and setting primary image set', function() {
+  expect(2);
+  signInAndVisit('/lion/2');
+
+  click('.image-thumbnail');
+
+  andThen(function() {
+    expectElement('.row.active');
+
+    stubRequest('put', '/lions/2', function(request){
+      ok(true, 'put api called');
+      return this.success(stubLionJSON());
+    });
+
+    click('.make-primary');
   });
 });

--- a/tests/helpers/fake-requests.js
+++ b/tests/helpers/fake-requests.js
@@ -151,6 +151,7 @@ function stubGetUser() {
 
 export {
   stubGetLions,
+  stubLionJSON,
   stubGetOrganizations,
   stubGetImageSets,
   stubGetImageSet,

--- a/tests/unit/controllers/lion-test.js
+++ b/tests/unit/controllers/lion-test.js
@@ -1,0 +1,15 @@
+import {
+  moduleFor,
+  test
+} from 'ember-qunit';
+
+moduleFor('controller:lion', 'LionController', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function() {
+  var controller = this.subject();
+  ok(controller);
+});


### PR DESCRIPTION
@redyaffle for you.

This edits the page for an individual lion to have a selectable list of image sets with some actions for them (view and make primary). 

It would be great if you could merge this and then work on the style and fleshing out this page. Right now the meta data at the top comes off the primary image set, so we need a similar but slightly different component to edit lion meta data, Also the galleries for each image set need to be a lot smaller.

I've already set up the api to update lions on the latest version of master on the api branch.

Here's what it looks like

![](http://g.recordit.co/EY4M898DHk.gif)
