### PR TITLE
Punchlist redux

### DIFF
--- a/app/components/lg-lion-editor.js
+++ b/app/components/lg-lion-editor.js
@@ -81,6 +81,7 @@ export default Ember.Component.extend({
 
         if(confirm(message)) {
           // automatically set is Verified to false when changing organization
+          this.set('lion.primaryImageSet.organization', selectedOrganization);
           this.set('selectedIsVerified', false);
           this.finishEditing();
         }

--- a/app/controllers/image-set.js
+++ b/app/controllers/image-set.js
@@ -18,8 +18,8 @@ export default Ember.Controller.extend({
   newCvRequest: null,
 
   isOwner: function() {
-    return this.get('currentUser.organization') === this.get('model.organization');
-  }.property('currentUser.organization', 'model.organization'),
+    return this.get('currentUser.organization.id') === this.get('model.organization.id');
+  }.property('currentUser.organization.id', 'model.organization.id'),
 
   creatingNewImageSet: function() {
     return !this.get('model.id');

--- a/app/controllers/image-sets/index.js
+++ b/app/controllers/image-sets/index.js
@@ -26,8 +26,8 @@ export default Ember.Controller.extend({
   }.property('activeImageSet', 'activeImageSet.hasCvRequest'),
 
   isOwner: function() {
-    return this.get('activeImageSet.organization') === this.get('currentOrganization');
-  }.property('activeImageSet.organization', 'currentOrganization'),
+    return this.get('activeImageSet.organization.id') === this.get('currentOrganization.id');
+  }.property('activeImageSet.organization.id', 'currentOrganization.id'),
 
   canDelete: Ember.computed.alias('isOwner'),
 

--- a/app/controllers/lion.js
+++ b/app/controllers/lion.js
@@ -5,8 +5,8 @@ export default Ember.Controller.extend({
   activeImageSet: null,
 
   isOwner: function() {
-    return this.get('model.organization') === this.get('currentUser.organization');
-  }.property('model.organization', 'currentUser.organization'),
+    return this.get('model.organization.id') === this.get('currentUser.organization.id');
+  }.property('model.organization.id', 'currentUser.organization.id'),
 
   canEdit: function() {
     return this.get('activeImageSet') && this.get('isOwner');

--- a/app/controllers/lions/search.js
+++ b/app/controllers/lions/search.js
@@ -11,8 +11,8 @@ export default Ember.Controller.extend({
         lion = this.get('activeLion');
 
     return user && lion &&
-      (user.get('organization.name') === lion.get('organization.name'));
-  }.property('user.organization', 'activeLion.organization'),
+      (user.get('organization.id') === lion.get('organization.id'));
+  }.property('user.organization.id', 'activeLion.organization.id'),
 
   actions: {
     displayResults: function(lions) {

--- a/app/controllers/lions/search.js
+++ b/app/controllers/lions/search.js
@@ -11,7 +11,7 @@ export default Ember.Controller.extend({
         lion = this.get('activeLion');
 
     return user && lion &&
-      (user.get('organization') === lion.get('organization'));
+      (user.get('organization.name') === lion.get('organization.name'));
   }.property('user.organization', 'activeLion.organization'),
 
   actions: {

--- a/app/models/image-set.js
+++ b/app/models/image-set.js
@@ -31,8 +31,8 @@ export default DS.Model.extend({
   }.property('dateOfBirth'),
 
   isPrimary: function() {
-    return this === this.get('lion.primaryImageSet');
-  }.property('lion'),
+    return this.get('id') === this.get('lion.primaryImageSet.id');
+  }.property('lion.primaryImageSet.id'),
 
   cvRequestPending: function() {
     return this.get('hasCvRequest') && !this.get('hasCvResults');


### PR DESCRIPTION
@bantic This completes a handful of Punchlist items: 
- fix canDelete to be able to delete lions on /lions/search
- fix isPrimary css class so primary image sets show up with orange highlighting
- compare organization.id === organization.id, instead of organization === organization. This addresses a handful of scattered bugs
- transfer ownership of primary image set when lion ownership is transferred

For your review! Thanks! 
